### PR TITLE
feat(pwd-length): Long passwords should be pre-hashed

### DIFF
--- a/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
+++ b/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
@@ -39,12 +39,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public String encode(final String rawPassword, final int iterations) {
         final int cost = iterations == -1 ? defaultIterations : iterations;
-        char[] pw = rawPassword.toCharArray();
-        if (pw.length > BCrypt.Version.MAX_PW_LENGTH_BYTE - 1) {
-            return BCrypt.with(LongPasswordStrategies.hashSha512(BCrypt.Version.VERSION_2Y)).hashToString(cost, pw);
-        } else {
-            return BCrypt.with(BCrypt.Version.VERSION_2Y).hashToString(cost, rawPassword.toCharArray());
-        }
+        return BCrypt.with(LongPasswordStrategies.hashSha512(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR)).hashToString(cost, rawPassword.toCharArray());
     }
 
     @Override
@@ -56,12 +51,13 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     public boolean verify(final String rawPassword, final PasswordCredentialModel credential) {
         final String hash = credential.getPasswordSecretData().getValue();
         char[] pw = rawPassword.toCharArray();
-        if (pw.length > BCrypt.Version.MAX_PW_LENGTH_BYTE - 1) {
-            final BCrypt.Result verifier = BCrypt.verifyer(BCrypt.Version.VERSION_2Y, LongPasswordStrategies.truncate(BCrypt.Version.VERSION_2Y)).verify(pw, hash);
-            return verifier.verified;
-        } else {
-            final BCrypt.Result verifier = BCrypt.verifyer(BCrypt.Version.VERSION_2Y).verify(pw, hash.toCharArray());
-            return verifier.verified;
+        final BCrypt.Result longPasswordVerifier = BCrypt.verifyer(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR, LongPasswordStrategies.hashSha512(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR)).verify(pw, hash);
+        if (longPasswordVerifier.verified) {
+            return longPasswordVerifier.verified;
         }
+
+        // If password is not verified (i.e. no match) verify using v2A of Blowfish algo
+        final BCrypt.Result verifier = BCrypt.verifyer(BCrypt.Version.VERSION_2A).verify(pw, hash.toCharArray());
+        return verifier.verified;
     }
 }

--- a/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
+++ b/src/main/java/com/github/leroyguillaume/keycloak/bcrypt/BCryptPasswordHashProvider.java
@@ -39,7 +39,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     @Override
     public String encode(final String rawPassword, final int iterations) {
         final int cost = iterations == -1 ? defaultIterations : iterations;
-        return BCrypt.with(LongPasswordStrategies.hashSha512(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR)).hashToString(cost, rawPassword.toCharArray());
+        return BCrypt.with(LongPasswordStrategies.truncate(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR)).hashToString(cost, rawPassword.toCharArray());
     }
 
     @Override
@@ -51,7 +51,7 @@ public class BCryptPasswordHashProvider implements PasswordHashProvider {
     public boolean verify(final String rawPassword, final PasswordCredentialModel credential) {
         final String hash = credential.getPasswordSecretData().getValue();
         char[] pw = rawPassword.toCharArray();
-        final BCrypt.Result longPasswordVerifier = BCrypt.verifyer(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR, LongPasswordStrategies.hashSha512(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR)).verify(pw, hash);
+        final BCrypt.Result longPasswordVerifier = BCrypt.verifyer(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR, LongPasswordStrategies.truncate(BCrypt.Version.VERSION_2Y_NO_NULL_TERMINATOR)).verify(pw, hash);
         if (longPasswordVerifier.verified) {
             return longPasswordVerifier.verified;
         }


### PR DESCRIPTION
## Why

Northstar has an established limit of 72bytes which appear to mirror what is expected by the Blowfish algorithm: https://github.com/fastly/Northstar/blob/master/app/models/user.rb#L51

Earlier versions of this algorithm expected a null-terminating character as the final byte `\x00`. It is however very possible that the 72nd byte in an NS password may be populated by a meaningful character. This would cause the java implementation to fail because the expectation for the final char is not met.

It is not possible to update the Version of Blowfish used by the `keycloak-bcrypt` plugin https://github.com/patrickfav/bcrypt/issues/43. 

## How 

First this code bumps the version of the plugin to `v1.6.0`. Note the difference in bcrypt algorithm used:

https://github.com/leroyguillaume/keycloak-bcrypt/compare/1.5.1...v1.6.0#diff-433c36ea458cdeaadc36c3e5b4c7ce3cfc990913b31d08ad6946ab5504c6aca6L41

Next this code checks raw password length and choose the appropriate strategy. For less than 72 bytes we use the plugin default, for more than this we pre-hash the password. This should be fine for our purposed because the version of `ruby-bcrypt` used by Northstar does not pre-hash and NS itself does not do it:

https://github.com/bcrypt-ruby/bcrypt-ruby/blob/v3.1.7/lib/bcrypt/password.rb#L46 -> https://github.com/bcrypt-ruby/bcrypt-ruby/blob/master/lib/bcrypt/engine.rb#L70


Ticket: https://fastly.atlassian.net/browse/PXENG-5796

Reference: https://fastly.slack.com/archives/C049DFDEZ2B/p1709019574872929